### PR TITLE
Improve wording and provide tutorial to detach fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Magisk on WSA (with Google Apps)
 
-:warning: For fork developers: Please detach the fork from [upstream](https://github.com/LSPosed/MagiskOnWSALocal) before building with Actions, Github will count the forked Actions usage to the upstream repository, which means if a forked repository abuses Actions, the repository that gets disabled will be upstream. We are not against forks, but please detach them from our repository. If you do not make changes one day after receiving the detachment request, our organization will ban you.
+:warning: For fork developers: Please [use the GitHub Support virtual assistant chatbot](https://support.github.com/contact?flow=detach_fork&subject=Detach%20Fork&tags=rr-forks) to detach your fork from [upstream](https://github.com/LSPosed/MagiskOnWSALocal) before building with GitHub Actions, as GitHub will count your forked GitHub Actions usage agasint this upstream repository GitHub Actions usage, which causes this upstream repository gets disabled by GitHub employee(s) due to numerous forks building GitHub Actions, and counting the forks' GitHub Action builds agasint this upstream repository GitHub Actions usage as abusing GitHub Actions.
+We are not against forks, but please detach them from our repository. If you do not make changes one day after receiving the detachment request, our organization will ban you.
+
+<details>
+    <summary>How to detach your fork from this upstream repository (a visual guide):</summary>
+    ![How to detach form using GitHub Support virtual assistant chatbot](https://user-images.githubusercontent.com/96967473/194208623-194e5926-feb9-4172-b57f-a82179245d02.png)
+ </details>
+
 
 ## Support for generating from these systems
 


### PR DESCRIPTION
I'm rewriting README.md to drive the point that is imperative to detach fork from upstream and inserting clickable links that shows the virtual assistant chatbot link to follow.

Also change link from https://support.github.com/request?q=Attach%2C+detach+or+reroute+forks#:~:text=our%20virtual%20assistant%20can%20help%20with%20detaching%2Funforking%20a%20repository as this commit https://github.com/orariley70/MagiskOnWSALocal/commit/130788222dcfa22ea218740704c3a784a4675c4a to https://support.github.com/contact?flow=detach_fork&subject=Detach%20Fork&tags=rr-forks per this commit: https://github.com/LSPosed/MagiskOnWSALocal/pull/168#issuecomment-1269963145

This is a continuation from [this ](https://github.com/LSPosed/MagiskOnWSALocal/pull/168 )pull request which became invalid as the fork has been detached since I submitted a detach fork request to GitHub at the point of the pull request.